### PR TITLE
Add similar.earth to Apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -265,6 +265,7 @@
 - [A searchable list of all publicly available Google Earth Engine Apps](https://datawrapper.dwcdn.net/4cHkZ/1/)
 - [Earth Engine App Filter](https://philippgaertner-ee-appshot-streamlit-filte-streamlit-app-j29b7u.streamlit.app/) by Philipp Gärtner
 - [LYRASENSE](https://lyrasense.com) - Agentic AI platform for Google Earth Engine with notebook environment, 28+ analysis templates, and automated satellite data workflows.
+- [Similar Earth](https://similar.earth) - Open source similarity search engine built on AlphaEarth to find places on Earth that look alike.
 
 ## Free Courses
 


### PR DESCRIPTION
Adding Similar Earth to the Apps section.

Open source planet-scale similarity search application on top of AlphaEarth.

- app: https://similar.earth
- gh: https://github.com/pariosur/similar-earth